### PR TITLE
Use tldr `main` branch instead of `master`

### DIFF
--- a/data.sh
+++ b/data.sh
@@ -4,8 +4,8 @@ cwd="$PWD"
 
 rm -fr data
 mkdir data
-curl -sSL https://github.com/tldr-pages/tldr/raw/master/LICENSE.md -o LICENSE-tldr-pages
-curl -sSL https://github.com/tldr-pages/tldr/archive/master.tar.gz | tar --transform 's/\.md//' -xz --directory data tldr-master/pages/ --strip-components=2
+curl -sSL https://github.com/tldr-pages/tldr/raw/main/LICENSE.md -o LICENSE-tldr-pages
+curl -sSL https://github.com/tldr-pages/tldr/archive/main.tar.gz | tar --transform 's/\.md//' -xz --directory data tldr-master/pages/ --strip-components=2
 cd "$cwd"/data/common && go run 4d63.com/embedfiles -out ../../data_common.go -file-names-var commonFileNames -files-var commonFiles .
 cd "$cwd"/data/linux && go run 4d63.com/embedfiles -out ../../data_linux.go .
 cd "$cwd"/data/osx && go run 4d63.com/embedfiles -out ../../data_darwin.go .


### PR DESCRIPTION
[About 1.5 years ago](https://github.com/tldr-pages/tldr/discussions/5868), we deprecated the master branch in favour of the main branch. We intend to remove it  [likely by May 1st 2023](https://github.com/tldr-pages/tldr/issues/9628).